### PR TITLE
logger -> LogFunc

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -36,6 +36,8 @@ func New() *Stats {
 
 // Stop ticker.
 func (s *Stats) Stop() {
+	s.Lock()
+	defer s.Unlock()
 	s.tick.Stop()
 }
 
@@ -47,6 +49,9 @@ func (s *Stats) TickEvery(d time.Duration) {
 
 // TickEveryTo `d` to the given logger.
 func (s *Stats) TickEveryTo(d time.Duration, log LogFunc) {
+	s.Lock()
+	defer s.Unlock()
+
 	s.tick = time.NewTicker(d)
 	for _ = range s.tick.C {
 		s.Write(log)

--- a/stats.go
+++ b/stats.go
@@ -120,7 +120,7 @@ func (s *Stats) Write(log LogFunc) {
 
 	for _, stat := range stats {
 		total := humanize.Comma(s.t[stat.name])
-		log("%s %.2f/s (%s)\n", stat.name, float64(stat.value)/secs, total)
+		log("%s %.2f/s (%s)", stat.name, float64(stat.value)/secs, total)
 	}
 
 	log("---")

--- a/stats.go
+++ b/stats.go
@@ -116,12 +116,12 @@ func (s *Stats) Write(log LogFunc) {
 
 	secs := time.Since(s.lastReset).Seconds()
 
-	log("---")
+	log("")
 
 	for _, stat := range stats {
 		total := humanize.Comma(s.t[stat.name])
 		log("%s %.2f/s (%s)", stat.name, float64(stat.value)/secs, total)
 	}
 
-	log("---")
+	log("")
 }

--- a/stats.go
+++ b/stats.go
@@ -53,7 +53,7 @@ func (s *Stats) TickEveryTo(d time.Duration, log LogFunc) {
 	s.tick = time.NewTicker(d)
 	s.Unlock()
 
-	for _ = range s.tick.C {
+	for range s.tick.C {
 		s.Write(log)
 	}
 }

--- a/stats.go
+++ b/stats.go
@@ -50,9 +50,9 @@ func (s *Stats) TickEvery(d time.Duration) {
 // TickEveryTo `d` to the given logger.
 func (s *Stats) TickEveryTo(d time.Duration, log LogFunc) {
 	s.Lock()
-	defer s.Unlock()
-
 	s.tick = time.NewTicker(d)
+	s.Unlock()
+
 	for _ = range s.tick.C {
 		s.Write(log)
 	}


### PR DESCRIPTION
Most loggers have an interface of `(string, ...interface{})`, where only go's std logger has `.Output()` thing.
